### PR TITLE
fix spelling

### DIFF
--- a/lib/Data/Session/Base.pm
+++ b/lib/Data/Session/Base.pm
@@ -89,7 +89,7 @@ Print the string to STDERR.
 
 If $s is empty, use '' (the empty string), to avoid a warning message.
 
-Lastly, the string is output preceeded by a '#', so it does not interfere with test output.
+Lastly, the string is output preceded by a '#', so it does not interfere with test output.
 That is, log($s) emulates diag $s.
 
 =head1 Support


### PR DESCRIPTION
In Debian we are currently applying the following patch to
Data-Session.
We thought you might be interested in it too.


The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libdata-session-perl/-/raw/debian/latest/debian/patches/spelling.patch

Thanks for considering,
  Mason James,
  Debian Perl Group
